### PR TITLE
Engine: fix "no such directory error"

### DIFF
--- a/ffplayout-engine/Dockerfile
+++ b/ffplayout-engine/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install supervisor
 RUN cd /opt && \
     wget "https://github.com/ffplayout/ffplayout-engine/archive/v${version}.zip" && \
     unzip "v${version}.zip" && \
-    mv "ffplayout-engine-${version}" 'ffplayout-engine' && \
+    mv "ffplayout_engine-${version}" 'ffplayout-engine' && \
     rm "v${version}.zip" && \
     cd ffplayout-engine && \
     pip install --no-cache-dir -r requirements-base.txt && \


### PR DESCRIPTION
Hi! It seems there is a build issue: the folder inside the .zip archive has ["ffplayout_engine-3.1.0"](https://gyazo.com/c79119ed9ca99d6f977298b42dcfff57) name (with an underscore) instead of the expected ["ffplayout-engine-3.1.0"](https://gyazo.com/e347c715e88dab2ba64f3fcdd2e22791) 